### PR TITLE
feat: support stop semantics

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -68,7 +68,7 @@ func (v *Validator) Validate(value interface{}, checkAll ...bool) error {
 			if all {
 				return nil
 			}
-			return io.EOF
+			return io.ErrUnexpectedEOF
 		}
 		nilParentFields := make(map[string]bool, 16)
 		err = te.Range(func(eh *tagexpr.ExprHandler) error {
@@ -107,14 +107,14 @@ func (v *Validator) Validate(value interface{}, checkAll ...bool) error {
 			if all {
 				return nil
 			}
-			return io.EOF
+			return io.ErrUnexpectedEOF
 		})
 		if err != nil && !all {
 			return err
 		}
 		return nil
 	})
-	if err != io.EOF && err != nil {
+	if err != io.ErrUnexpectedEOF && err != nil {
 		return err
 	}
 	switch len(errs) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -80,6 +80,9 @@ func (v *Validator) Validate(value interface{}, checkAll ...bool) error {
 				return nil
 			}
 			rerr, ok := r.(error)
+			if errors.Is(rerr, tagexpr.ErrStop) {
+				return rerr
+			}
 			if !ok && tagexpr.FakeBool(r) {
 				return nil
 			}


### PR DESCRIPTION
close #34 

If a custom function returns ErrStop, the field checks after this field where in the same struct are stopped.

Update:
Use io.ErrUnexpectedEOF in the validator to indicate an error in the validation.

Hi, since io.EOF is used in validator, I use io.EOF to represent stopping the validation of the current struct fields. Please help to see if this way is possible
