### PR TITLE
fix returned error type

### DIFF
--- a/binding/param_info.go
+++ b/binding/param_info.go
@@ -243,8 +243,9 @@ func (p *paramInfo) bindStringSlice(info *tagInfo, expr *tagexpr.TagExpr, a []st
 		vv, err := fn(a[0], p.looseZeroMode)
 		if err == nil {
 			v.Set(vv)
+			return nil
 		}
-		return err
+		return info.typeError
 	}
 
 	switch v.Kind() {


### PR DESCRIPTION
If the error comes from custom unmarshal function, we should return `info.typeError` instead of the error itself for backward compatibility