### PR TITLE
feat: improve performance of type cache

### DIFF
--- a/binding/gjson/internal/caching/fcache.go
+++ b/binding/gjson/internal/caching/fcache.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package caching
+
+import (
+    `strings`
+    `unsafe`
+
+    `github.com/bytedance/go-tagexpr/v2/binding/gjson/internal/rt`
+)
+
+type FieldMap struct {
+    N uint64
+    b unsafe.Pointer
+    m map[string]int
+}
+
+type FieldEntry struct {
+    ID   int
+    Name string
+    Hash uint64
+}
+
+const (
+    FieldMap_N     = int64(unsafe.Offsetof(FieldMap{}.N))
+    FieldMap_b     = int64(unsafe.Offsetof(FieldMap{}.b))
+	FieldEntrySize = int64(unsafe.Sizeof(FieldEntry{}))
+)
+
+func newBucket(n int) unsafe.Pointer {
+    v := make([]FieldEntry, n)
+    return (*rt.GoSlice)(unsafe.Pointer(&v)).Ptr
+}
+
+func CreateFieldMap(n int) *FieldMap {
+    return &FieldMap {
+        N: uint64(n * 2),
+        b: newBucket(n * 2),    // LoadFactor = 0.5
+        m: make(map[string]int, n * 2),
+    }
+}
+
+func (self *FieldMap) At(p uint64) *FieldEntry {
+    off := uintptr(p) * uintptr(FieldEntrySize)
+    return (*FieldEntry)(unsafe.Pointer(uintptr(self.b) + off))
+}
+
+// Get searches FieldMap by name. JIT generated assembly does NOT call this
+// function, rather it implements its own version directly in assembly. So
+// we must ensure this function stays in sync with the JIT generated one.
+func (self *FieldMap) Get(name string) int {
+    h := StrHash(name)
+    p := h % self.N
+    s := self.At(p)
+
+    /* find the element;
+     * the hash map is never full, so the loop will always terminate */
+    for s.Hash != 0 {
+        if s.Hash == h && s.Name == name {
+            return s.ID
+        } else {
+            p = (p + 1) % self.N
+            s = self.At(p)
+        }
+    }
+
+    /* not found */
+    return -1
+}
+
+func (self *FieldMap) Set(name string, i int) {
+    h := StrHash(name)
+    p := h % self.N
+    s := self.At(p)
+
+    /* searching for an empty slot;
+     * the hash map is never full, so the loop will always terminate */
+    for s.Hash != 0 {
+        p = (p + 1) % self.N
+        s = self.At(p)
+    }
+
+    /* set the value */
+    s.ID   = i
+    s.Hash = h
+    s.Name = name
+
+    /* add the case-insensitive version, prefer the one with smaller field ID */
+    key := strings.ToLower(name)
+    if v, ok := self.m[key]; !ok || i < v {
+        self.m[key] = i
+    }
+}
+
+func (self *FieldMap) GetCaseInsensitive(name string) int {
+    if i, ok := self.m[strings.ToLower(name)]; ok {
+        return i
+    } else {
+        return -1
+    }
+}

--- a/binding/gjson/internal/caching/hashing.go
+++ b/binding/gjson/internal/caching/hashing.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package caching
+
+import (
+    `unsafe`
+
+    `github.com/bytedance/go-tagexpr/v2/binding/gjson/internal/rt`
+)
+
+var (
+    V_strhash = rt.UnpackEface(strhash)
+    S_strhash = *(*uintptr)(V_strhash.Value)
+)
+
+//go:noescape
+//go:linkname strhash runtime.strhash
+func strhash(_ unsafe.Pointer, _ uintptr) uintptr
+
+func StrHash(s string) uint64 {
+    if v := strhash(unsafe.Pointer(&s), 0); v == 0 {
+        return 1
+    } else {
+        return uint64(v)
+    }
+}

--- a/binding/gjson/internal/caching/hashing_test.go
+++ b/binding/gjson/internal/caching/hashing_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package caching
+
+import (
+    `fmt`
+    `testing`
+    `unsafe`
+
+    `github.com/bytedance/go-tagexpr/v2/binding/gjson/internal/rt`
+)
+
+const (
+    _H_basis uint64 = 0xcbf29ce484222325
+    _H_prime uint64 = 0x00000100000001b3
+)
+
+func fnv1a(s string) uint64 {
+    v := _H_basis
+    m := (*rt.GoString)(unsafe.Pointer(&s))
+
+    /* hash each byte */
+    for i := 0; i < m.Len; i++ {
+        v ^= uint64(*(*uint8)(unsafe.Pointer(uintptr(m.Ptr) + uintptr(i))))
+        v *= _H_prime
+    }
+
+    /* never returns 0 for hash */
+    if v == 0 {
+        return 1
+    } else {
+        return v
+    }
+}
+
+func TestHashing_Fnv1a(t *testing.T) {
+    fmt.Printf("%#x\n", fnv1a("hello, world"))
+}
+
+func TestHashing_StrHash(t *testing.T) {
+    s := "hello, world"
+    fmt.Printf("%#x\n", StrHash(s))
+}
+
+var fn_fnv1a = fnv1a
+func BenchmarkHashing_Fnv1a(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        fn_fnv1a("accountid_interval_aweme_second")
+    }
+}
+
+func BenchmarkHashing_StrHash(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        StrHash("accountid_interval_aweme_second")
+    }
+}

--- a/binding/gjson/internal/caching/pcache.go
+++ b/binding/gjson/internal/caching/pcache.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package caching
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/bytedance/go-tagexpr/v2/binding/gjson/internal/rt"
+)
+
+/** Program Map **/
+
+const (
+	_LoadFactor   = 0.5
+	_InitCapacity = 4096 // must be a power of 2
+)
+
+type _ProgramMap struct {
+	n uint64
+	m uint32
+	b []_ProgramEntry
+}
+
+type _ProgramEntry struct {
+	vt *rt.GoType
+	fn interface{}
+}
+
+func newProgramMap() *_ProgramMap {
+	return &_ProgramMap{
+		n: 0,
+		m: _InitCapacity - 1,
+		b: make([]_ProgramEntry, _InitCapacity),
+	}
+}
+
+func (mips *_ProgramMap) copy() *_ProgramMap {
+	fork := &_ProgramMap{
+		n: mips.n,
+		m: mips.m,
+		b: make([]_ProgramEntry, len(mips.b)),
+	}
+	for i, f := range mips.b {
+		fork.b[i] = f
+	}
+	return fork
+}
+
+func (mips *_ProgramMap) get(vt *rt.GoType) interface{} {
+	i := mips.m + 1
+	p := vt.Hash & mips.m
+
+	/* linear probing */
+	for ; i > 0; i-- {
+		if b := mips.b[p]; b.vt == vt {
+			return b.fn
+		} else {
+			p = (p + 1) & mips.m
+		}
+	}
+
+	/* not found */
+	return nil
+}
+
+func (mips *_ProgramMap) add(vt *rt.GoType, fn interface{}) *_ProgramMap {
+	p := mips.copy()
+	f := float64(atomic.LoadUint64(&p.n)+1) / float64(p.m+1)
+
+	/* check for load factor */
+	if f > _LoadFactor {
+		p = p.rehash()
+	}
+
+	/* insert the value */
+	p.insert(vt, fn)
+	return p
+}
+
+func (mips *_ProgramMap) rehash() *_ProgramMap {
+	c := (mips.m + 1) << 1
+	r := &_ProgramMap{m: c - 1, b: make([]_ProgramEntry, int(c))}
+
+	/* rehash every entry */
+	for i := uint32(0); i <= mips.m; i++ {
+		if b := mips.b[i]; b.vt != nil {
+			r.insert(b.vt, b.fn)
+		}
+	}
+
+	/* rebuild successful */
+	return r
+}
+
+func (mips *_ProgramMap) insert(vt *rt.GoType, fn interface{}) {
+	h := vt.Hash
+	p := h & mips.m
+
+	/* linear probing */
+	for i := uint32(0); i <= mips.m; i++ {
+		if b := &mips.b[p]; b.vt != nil {
+			p += 1
+			p &= mips.m
+		} else {
+			b.vt = vt
+			b.fn = fn
+			atomic.AddUint64(&mips.n, 1)
+			return
+		}
+	}
+
+	/* should never happen */
+	panic("no available slots")
+}
+
+/** RCU Program Cache **/
+
+type ProgramCache struct {
+	m sync.Mutex
+	p unsafe.Pointer
+}
+
+func CreateProgramCache() *ProgramCache {
+	return &ProgramCache{
+		m: sync.Mutex{},
+		p: unsafe.Pointer(newProgramMap()),
+	}
+}
+
+func (c *ProgramCache) Get(vt *rt.GoType) interface{} {
+	return (*_ProgramMap)(atomic.LoadPointer(&c.p)).get(vt)
+}
+
+func (c *ProgramCache) Compute(vt *rt.GoType, compute func(*rt.GoType) (interface{}, error)) (interface{}, error) {
+	var err error
+	var val interface{}
+
+	/* use defer to prevent inlining of this function */
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	/* double check with write lock held */
+	if val = c.Get(vt); val != nil {
+		return val, nil
+	}
+
+	/* compute the value */
+	if val, err = compute(vt); err != nil {
+		return nil, err
+	}
+
+	/* update the RCU cache */
+	atomic.StorePointer(&c.p, unsafe.Pointer((*_ProgramMap)(atomic.LoadPointer(&c.p)).add(vt, val)))
+	return val, nil
+}

--- a/binding/gjson/internal/caching/pcache_test.go
+++ b/binding/gjson/internal/caching/pcache_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package caching
+
+import (
+	"sync"
+	"testing"
+
+
+	"github.com/bytedance/go-tagexpr/v2/binding/gjson/internal/rt"
+)
+
+func TestPcacheRace(t *testing.T) {
+	t.Parallel()
+
+	pc := CreateProgramCache()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	start := make(chan struct{}, 2)
+
+	go func() {
+		defer wg.Done()
+		var k = map[string]interface{}{}
+		<-start
+		for i := 0; i < 100; i++ {
+			_, _ = pc.Compute(rt.UnpackEface(k).Type, func(_ *rt.GoType) (interface{}, error) {
+				return map[string]interface{}{}, nil
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		var k = map[string]interface{}{}
+		<-start
+		for i := 0; i < 100; i++ {
+			v := pc.Get(rt.UnpackEface(k).Type)
+			t.Log(k, v)
+		}
+	}()
+
+	start <- struct{}{}
+	start <- struct{}{}
+	wg.Wait()
+}

--- a/binding/gjson/internal/rt/fastvalue.go
+++ b/binding/gjson/internal/rt/fastvalue.go
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rt
+
+import (
+    `reflect`
+    `unsafe`
+)
+
+var (
+	reflectRtypeItab = findReflectRtypeItab()
+)
+
+const (
+    F_direct    = 1 << 5
+    F_kind_mask = (1 << 5) - 1
+)
+
+type GoType struct {
+    Size       uintptr
+    PtrData    uintptr
+    Hash       uint32
+    Flags      uint8
+    Align      uint8
+    FieldAlign uint8
+    KindFlags  uint8
+    Traits     unsafe.Pointer
+    GCData     *byte
+    Str        int32
+    PtrToSelf  int32
+}
+
+func (self *GoType) Kind() reflect.Kind {
+    return reflect.Kind(self.KindFlags & F_kind_mask)
+}
+
+func (self *GoType) Pack() (t reflect.Type) {
+    (*GoIface)(unsafe.Pointer(&t)).Itab = reflectRtypeItab
+    (*GoIface)(unsafe.Pointer(&t)).Value = unsafe.Pointer(self)
+    return
+}
+
+func (self *GoType) String() string {
+    return self.Pack().String()
+}
+
+type GoMap struct {
+    Count      int
+    Flags      uint8
+    B          uint8
+    Overflow   uint16
+    Hash0      uint32
+    Buckets    unsafe.Pointer
+    OldBuckets unsafe.Pointer
+    Evacuate   uintptr
+    Extra      unsafe.Pointer
+}
+
+type GoMapIterator struct {
+    K           unsafe.Pointer
+    V           unsafe.Pointer
+    T           *GoMapType
+    H           *GoMap
+    Buckets     unsafe.Pointer
+    Bptr        *unsafe.Pointer
+    Overflow    *[]unsafe.Pointer
+    OldOverflow *[]unsafe.Pointer
+    StartBucket uintptr
+    Offset      uint8
+    Wrapped     bool
+    B           uint8
+    I           uint8
+    Bucket      uintptr
+    CheckBucket uintptr
+}
+
+type GoItab struct {
+    it unsafe.Pointer
+    Vt *GoType
+    hv uint32
+    _  [4]byte
+    fn [1]uintptr
+}
+
+type GoIface struct {
+    Itab  *GoItab
+    Value unsafe.Pointer
+}
+
+type GoEface struct {
+    Type  *GoType
+    Value unsafe.Pointer
+}
+
+func (self GoEface) Pack() (v interface{}) {
+    *(*GoEface)(unsafe.Pointer(&v)) = self
+    return
+}
+
+type GoPtrType struct {
+    GoType
+    Elem *GoType
+}
+
+type GoMapType struct {
+    GoType
+    Key        *GoType
+    Elem       *GoType
+    Bucket     *GoType
+    Hasher     func(unsafe.Pointer, uintptr) uintptr
+    KeySize    uint8
+    ElemSize   uint8
+    BucketSize uint16
+    Flags      uint32
+}
+
+func (self *GoMapType) IndirectElem() bool {
+    return self.Flags & 2 != 0
+}
+
+type GoStructType struct {
+    GoType
+    Pkg    *byte
+    Fields []GoStructField
+}
+
+type GoStructField struct {
+    Name     *byte
+    Type     *GoType
+    OffEmbed uintptr
+}
+
+type GoInterfaceType struct {
+    GoType
+    PkgPath *byte
+    Methods []GoInterfaceMethod
+}
+
+type GoInterfaceMethod struct {
+    Name int32
+    Type int32
+}
+
+type GoSlice struct {
+    Ptr unsafe.Pointer
+    Len int
+    Cap int
+}
+
+type GoString struct {
+    Ptr unsafe.Pointer
+    Len int
+}
+
+func PtrElem(t *GoType) *GoType {
+    return (*GoPtrType)(unsafe.Pointer(t)).Elem
+}
+
+func MapType(t *GoType) *GoMapType {
+    return (*GoMapType)(unsafe.Pointer(t))
+}
+
+func IfaceType(t *GoType) *GoInterfaceType {
+    return (*GoInterfaceType)(unsafe.Pointer(t))
+}
+
+func UnpackType(t reflect.Type) *GoType {
+    return (*GoType)((*GoIface)(unsafe.Pointer(&t)).Value)
+}
+
+func UnpackEface(v interface{}) GoEface {
+    return *(*GoEface)(unsafe.Pointer(&v))
+}
+
+func UnpackIface(v interface{}) GoIface {
+    return *(*GoIface)(unsafe.Pointer(&v))
+}
+
+func findReflectRtypeItab() *GoItab {
+    v := reflect.TypeOf(struct{}{})
+    return (*GoIface)(unsafe.Pointer(&v)).Itab
+}


### PR DESCRIPTION
借鉴 sonic 对结构体信息缓存的方法，提升对结构体解析的性能，以下时在并发情况下的测试
```
goos: darwin
goarch: amd64
pkg: github.com/bytedance/go-tagexpr/v2/binding/gjson
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkGetFiledInfo-12               704923858                 1.79 ns/op
BenchmarkGetFieldInfoByMap-12           31975237                36.87 ns/op

goos: linux
goarch: amd64
pkg: github.com/bytedance/go-tagexpr/v2/binding/gjson
cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
BenchmarkGetFiledInfo-8        575396450	           2.42 ns/op
BenchmarkGetFieldInfoByMap-8   	23272125	          63.71 ns/op
```