### PR TITLE
fix: remove the return statement in the middle of the TestNilField test

### DIFF
--- a/tagexpr_test.go
+++ b/tagexpr_test.go
@@ -709,7 +709,6 @@ func TestNilField(t *testing.T) {
 		assert.True(t, r, eh.Path())
 		return nil
 	})
-	return
 
 	type (
 		N struct {


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>