### PR TITLE
fix: interface panic

### DIFF
--- a/binding/bind_test.go
+++ b/binding/bind_test.go
@@ -1196,3 +1196,14 @@ func TestVdTagRecursion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Less(t, int64(time.Since(start)), int64(time.Second))
 }
+
+func TestInterface(t *testing.T) {
+	type foo struct {
+		F1 interface{} `query:"f1"`
+	}
+	recv := &foo{}
+	req, _ := http.NewRequest("get", "http://localhost/?f1=f1", bytes.NewReader([]byte{}))
+	binder := binding.New(nil)
+	err := binder.BindAndValidate(recv, req, nil)
+	assert.NoError(t, err)
+}

--- a/binding/param_info.go
+++ b/binding/param_info.go
@@ -236,7 +236,9 @@ func (p *paramInfo) bindStringSlice(info *tagInfo, expr *tagexpr.TagExpr, a []st
 	}
 
 	v = ameda.DereferenceValue(v)
-
+	if !v.IsValid() {
+		return nil
+	}
 	// we have customized unmarshal defined, we should use it firstly
 	if fn, exist := typeUnmarshalFuncs[v.Type()]; exist {
 		vv, err := fn(a[0], p.looseZeroMode)


### PR DESCRIPTION
绑定 interface{} field类型的时候会 panic