### PR TITLE
fix: unsafe gjson

### DIFF
--- a/binding/gjson/gjson.go
+++ b/binding/gjson/gjson.go
@@ -57,7 +57,7 @@ func Unmarshal(data []byte, v interface{}) error {
 	if !ok {
 		val = reflect.ValueOf(v)
 	}
-	return assign(gjson.Parse(ameda.UnsafeBytesToString(data)), val)
+	return assign(gjson.ParseBytes(data), val)
 }
 
 // assign Unmarshal


### PR DESCRIPTION
自带的 gjson unmarshal 用了 unsafe 操作。在一些场景下用户传来的 body 会被修改，导致绑定后的数据的内存也被一同改变，出现数据不一致的问题。

这个提出来讨论下，要怎么规避下这个问题，毕竟这个 copy 一次开销还是很大的。 不过标准的 json 库为了保证安全，这里总是要 copy 一份的