### PR TITLE
optimize ast with constant folding

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -43,6 +43,7 @@ func parseExpr(expr string) (*Expr, error) {
 		return nil, err
 	}
 	sortPriority(e)
+	_, p.expr = e.Optimize()
 	return p, nil
 }
 func (p *Expr) parseExprNode(expr *string, e ExprNode) error {
@@ -262,6 +263,7 @@ type ExprNode interface {
 	SetRightOperand(ExprNode)
 	String() string
 	Run(context.Context, string, *TagExpr) interface{}
+	Optimize() (bool, ExprNode)
 }
 
 // var _ ExprNode = new(exprBackground)

--- a/spec_func.go
+++ b/spec_func.go
@@ -136,6 +136,10 @@ func (f *funcExprNode) Run(ctx context.Context, currField string, tagExpr *TagEx
 	return realValue(f.fn(args...), f.boolOpposite, f.signOpposite)
 }
 
+func (f *funcExprNode) Optimize() (bool, ExprNode) {
+	return false, f
+}
+
 // --------------------------- Built-in function ---------------------------
 func init() {
 	funcList["regexp"] = readRegexpFuncExprNode
@@ -282,6 +286,10 @@ func (re *regexpFuncExprNode) Run(ctx context.Context, currField string, tagExpr
 	return false
 }
 
+func (re *regexpFuncExprNode) Optimize() (bool, ExprNode) {
+	return false, re
+}
+
 type sprintfFuncExprNode struct {
 	exprBackground
 	format string
@@ -341,4 +349,8 @@ func (se *sprintfFuncExprNode) Run(ctx context.Context, currField string, tagExp
 		}
 	}
 	return fmt.Sprintf(se.format, args...)
+}
+
+func (se *sprintfFuncExprNode) Optimize() (bool, ExprNode) {
+	return false, se
 }

--- a/spec_range.go
+++ b/spec_range.go
@@ -74,6 +74,10 @@ func (re *rangeKvExprNode) Run(ctx context.Context, _ string, _ *TagExpr) interf
 	return realValue(v, re.boolOpposite, re.signOpposite)
 }
 
+func (re *rangeKvExprNode) Optimize() (bool, ExprNode) {
+	return false, re
+}
+
 type rangeFuncExprNode struct {
 	exprBackground
 	object       ExprNode
@@ -147,4 +151,8 @@ func (e *rangeFuncExprNode) Run(ctx context.Context, currField string, tagExpr *
 	default:
 	}
 	return r
+}
+
+func (re *rangeFuncExprNode) Optimize() (bool, ExprNode) {
+	return false, re
 }

--- a/spec_selector.go
+++ b/spec_selector.go
@@ -107,3 +107,7 @@ func (se *selectorExprNode) Run(ctx context.Context, currField string, tagExpr *
 	v := tagExpr.getValue(field, subFields)
 	return realValue(v, se.boolOpposite, se.signOpposite)
 }
+
+func (se *selectorExprNode) Optimize() (bool, ExprNode) {
+	return false, se
+}


### PR DESCRIPTION
### 常量折叠优化 提议
对表达式编译生成的 ast 中的常量进行预计算优化、以提高表达式执行性能


### 实现思路
1. 表达式结点添加 `Optimize() (bool, ExprNode)` 判断当前结点是否可以常量折叠优化、以及优化后的结点
```golang
type ExprNode interface {
        ......
	Optimize() (bool, ExprNode)
}
```

2.  判断叶子结点是否可以优化
比如数字结点总是可以优化
```golang
func (de *digitalExprNode) Optimize() (bool, ExprNode) {
	return true, de
}
```

3. 非叶子结点根据子节点判断当前阶段是否可以优化
比如乘法叶子结点都是可折叠的结点，则乘法结点也可以优化

```golang
func (ae *multiplicationExprNode) Optimize() (bool, ExprNode) {
	lsucc, newLeft := ae.leftOperand.Optimize()
	if lsucc {
		ae.leftOperand = newLeft
	}

	rSucc, newRight := ae.rightOperand.Optimize()
	if rSucc {
		ae.rightOperand = newRight
	}

	if lsucc && rSucc {
		v1, _ := toFloat64(ae.rightOperand.Run(context.Background(), "", nil), true)
		if v1 == 0 {
			return true, &digitalExprNode{val: math.NaN()}
		}
		v0, _ := toFloat64(ae.leftOperand.Run(context.Background(), "", nil), true)
		return true, &digitalExprNode{val: v0 * v1}
	}

	return false, ae
}
```