### PR TITLE
BugFix: Fixed Unsafe Zip Deserialization

### DIFF
--- a/binding/body.go
+++ b/binding/body.go
@@ -94,7 +94,9 @@ func GetBody(r *http.Request) (*Body, error) {
 			return nil, err
 		}
 		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r.Body)
+		// Maximum size of decompressed body size. Currently 256 MB
+		var maximumSizeLimit int64 = 256 * 1024 * 1024
+		_, _ = io.CopyN(&buf, r.Body, maximumSizeLimit)
 		_ = closeBody()
 		_body := &Body{
 			Buffer:    &buf,


### PR DESCRIPTION
## Summary
This PR fixes a potential zip deserialization bug in your code.


## Description
While triaging your project, our bug fixing tool generated the following diff(s)-
```diff
--- a/go-tagexpr/binding/body.go
+++ b/go-tagexpr/binding/body.go
@@ -85,6 +85,12 @@
 			r.Body = flate.NewReader(r.Body)
 		case "zlib":
 			var readCloser io.ReadCloser
+			// OpenRefactory Warning:
+			// Possible Untrusted Deserializaiton!
+			// Path:
+			//	File: body.go, Line: 88
+			//		zlib.NewReader(r.Body)
+			//		Tainted information is used in a sink.
 			readCloser, err = zlib.NewReader(r.Body)
 			if err == nil {
 				r.Body = readCloser
```

Here, the payload sent through `r.Body` is decompressed using `gzip`, `deflate`, and `zlib` based on the "Content-Encoding" header. However, the copy operation on [line 97](https://github.com/bytedance/go-tagexpr/blob/master/binding/body.go#L97) is unsafe because the compressed data inside `r.Body` can contain zip bomb that can lead to deflation of large amount of data, which can lead to a denial of service.

As a result, it is suggested that the `io.CopyN()` method is used with a maximum output limit (number of allowed bytes in the uncompressed data). Here, `256 MB` has been set as the limit.


## Comments
Even though the `GetBody()` method isn't used anywhere in the codebase except for the two test files, anyone using your project as a dependency can import and use the `GetBody()` method. As a result, having such a protection mechanism is the best option.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
