### PR TITLE
BugFix: Fixed Inappropriate Logical Expression

### DIFF
--- a/tagexpr.go
+++ b/tagexpr.go
@@ -573,7 +573,7 @@ func (s *structVM) newChildField(parent *fieldVM, child *fieldVM, toBind bool) *
 				for i := 0; i < parent.ptrDeep; i++ {
 					newField = newField.Elem()
 				}
-				if (newField == reflect.Value{}) || (!initZero && newField.IsNil()) {
+				if (newField.Interface() == reflect.Value{}.Interface()) || (!initZero && newField.IsNil()) {
 					return reflect.Value{}
 				}
 				return child.reflectValueGetter(unsafe.Pointer(newField.Pointer()), initZero)


### PR DESCRIPTION
## Summary
This PR fixes a logical bug in your codebase.


## Description
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [tagexpr.go](https://github.com/bytedance/go-tagexpr/blob/master/tagexpr.go#L576), a logical equality check operation is performed between two [`reflect.Value`](https://pkg.go.dev/reflect#Value) instances that represent run-time data. This is incorrect because it compares the `reflect` package's internal representations, which is typically not intended. Instead, the intent is most likely to compare the underlying values. iCR suggested that such comparison should be done with [`value.Interface()`](https://pkg.go.dev/reflect#Value.Interface).


## Changes
I have changed the comparison by using `Interface()` on both sides.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

